### PR TITLE
文字種変化時の条件の不具合を修正

### DIFF
--- a/lib/tenji/converter.rb
+++ b/lib/tenji/converter.rb
@@ -58,6 +58,8 @@ module Tenji
             redo
           end
           if char.match?(/[a-zA-Z]/)
+            # アルファベットで書かれた文字の前に外字符を入れて、alphabet状態に移行
+            result << Tenji::Mapping::GAIJIFU
             state = :alphabet
             redo
           end
@@ -68,7 +70,9 @@ module Tenji
             state = :kana
             redo
           end
-          if char == /[0-9]/
+          if char.match?(/[0-9]/)
+            # 数字がはじまる合図の数符を入れて、number状態に移行
+            result << Tenji::Mapping::SUFU
             state = :number
             redo
           end

--- a/spec/tenji_spec.rb
+++ b/spec/tenji_spec.rb
@@ -81,9 +81,14 @@ RSpec.describe Tenji do
     end
 
     context 'when text containing a mix of kanji, numbers, alphabets, and hiragana' do
-      it 'onverts numbers, alphabets, and hiragana, and removes all other characters' do
+      it 'converts numbers, alphabets, and hiragana, and removes all other characters' do
         text = 'その　人と　２ねんも　あってない。　けつえきがたわ　A B O AB　のどれ？　わ　びっくりした！'
         expect(converter.convert_to_tenji(text)).to eq('⠺⠎⠀⠞⠀⠼⠃⠏⠴⠾⠀⠁⠂⠟⠅⠃⠲⠀⠫⠝⠋⠣⠐⠡⠕⠄⠀⠰⠠⠁⠀⠰⠠⠃⠀⠰⠠⠕⠀⠰⠠⠠⠁⠃⠀⠎⠐⠞⠛⠢⠀⠄⠀⠐⠧⠂⠩⠓⠳⠕⠖')
+      end
+
+      it 'handles contiguous letters and hiragana without interrupting conversion' do
+        text = 'a5　abcそんぐ　1p　2にん　まる1　さいずA'
+        expect(converter.convert_to_tenji(text)).to eq('⠰⠁⠼⠑⠀⠰⠁⠃⠉⠺⠴⠐⠩⠀⠼⠁⠰⠏⠀⠼⠃⠇⠴⠀⠵⠙⠼⠁⠀⠱⠃⠐⠹⠰⠠⠁')
       end
     end
   end


### PR DESCRIPTION
アルファベットから数字へスペースなしで移行する時、一部の条件分岐が機能していなかったので修正。
数字からアルファベットへスペースなしで移行する時、外字符表示ができていなかったので追加。